### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ pod 'SwipeTableView'
 6. [Demo介绍](https://github.com/Roylee-ML/SwipeTableView/blob/master/README.md#使用的详细用法在swipetableviewdemo文件夹中提供了五种示例)
 
 <br>
-##实现的原理
+## 实现的原理
 >为了兼容下拉刷新，采用了两种实现方式，但基本构造都是一样的
       
-###Mode 1
+### Mode 1
 
 ![Mode 1](https://github.com/Roylee-ML/SwipeTableView/blob/master/ScreenShots/SwipeTableViewStruct1.png)
    
@@ -54,7 +54,7 @@ pod 'SwipeTableView'
  
  
  
-###Mode 2
+### Mode 2
 
 ![Mode 2](https://github.com/Roylee-ML/SwipeTableView/blob/master/ScreenShots/SwipeTableViewStruct2.png)
 
@@ -69,7 +69,7 @@ pod 'SwipeTableView'
 <br>
 # Basic Usage
 
-##怎样使用？使用方式类似UITableView
+## 怎样使用？使用方式类似UITableView
 
 **实现 `SwipeTableViewDataSource` 代理的两个方法：**
 
@@ -89,9 +89,9 @@ pod 'SwipeTableView'
 **使用的`swipeHeaderView`必须是`STHeaderView`及其子类的实例。**
  
 <br>
-##如何支持下拉刷新？
+## 如何支持下拉刷新？
 
-###下拉刷新有两种实现方式，一种用户自定义下拉刷新组件（局部修改自定义），一种是简单粗暴设置宏：
+### 下拉刷新有两种实现方式，一种用户自定义下拉刷新组件（局部修改自定义），一种是简单粗暴设置宏：
 
 <br>
 
@@ -172,7 +172,7 @@ or
 如果使用的下拉刷新控件的frame是变化的（个人感觉极少数），那么只能更深层的修改下拉刷新控件或者自定义下拉刷新。也可以更直接的采用第一种设置宏的方式支持下拉刷新。</br>
  
 <br>
-##混合模式（UItableView & UICollectionView & UIScrollView）
+## 混合模式（UItableView & UICollectionView & UIScrollView）
 
 1. 在`Mode 1`模式下，属于最基本的模式，可扩展性也是最强的，此时，支持`UITableView`、`UICollectionView`、`UIScrollView`。**如果，同时设置`shouldAdjustContentSize`为YES，实现自适应contentSize，在`UICollectionView`内容不足的添加下，只能使用`STCollectionView`及其子类**
    
@@ -181,8 +181,8 @@ or
 2. 在`Mode 2`模式下，**`SwipeTableView`支持的collectionView必须是`STCollectionView`及其子类的实例**，目前，不支持`UIScrollView`。
 
 <br>
-##**示例代码**：
-###初始化并设置header与bar
+## **示例代码**：
+### 初始化并设置header与bar
 ```objc
 self.swipeTableView = [[SwipeTableView alloc]initWithFrame:[UIScreen mainScreen].bounds];
 _swipeTableView.delegate = self;
@@ -192,7 +192,7 @@ _swipeTableView.swipeHeaderView = self.tableViewHeader;
 _swipeTableView.swipeHeaderBar = self.segmentBar;
 ```
    
-###实现数据源代理：
+### 实现数据源代理：
 ```objc
 - (NSInteger)numberOfItemsInSwipeTableView:(SwipeTableView *)swipeView {
     return 4;
@@ -212,7 +212,7 @@ _swipeTableView.swipeHeaderBar = self.segmentBar;
 }
 ```
    
-###`STCollectionView`使用方法：
+### `STCollectionView`使用方法：
 ```objc
 MyCollectionView.h
 
@@ -328,7 +328,7 @@ MyCollectionView.m
 <br>
 # Demo Info
 
-###使用的详细用法在SwipeTableViewDemo文件夹中，提供了五种示例：
+### 使用的详细用法在SwipeTableViewDemo文件夹中，提供了五种示例：
 
   - `SingleOneKindView`   
      数据源提供的是单一类型的itemView，这里默认提供的是 `CustomTableView` （`UITableView`的子类），并且每一个itemView的数据行数有多有少，因此在滑动到数据少的itemView时，再次触碰界面，当前的itemView会有回弹的动作（由于contentSize小的缘故）。

--- a/README_EN.md
+++ b/README_EN.md
@@ -32,10 +32,10 @@ pod 'SwipeTableView'
 6. [Demo Info](https://github.com/Roylee-ML/SwipeTableView/blob/master/README_EN.md#detailed-usages-are-in-the-swipetableviewdemo-folder-provide-five-examples)
 
 <br>
-##Principle
+## Principle
 >In order to be compatible with the pull to refresh, adopted two kinds of ways, but the basic structure is the same.
       
-###Mode 1
+### Mode 1
 
 ![Mode 1](https://github.com/Roylee-ML/SwipeTableView/blob/master/ScreenShots/SwipeTableViewStruct1.png)
    
@@ -54,7 +54,7 @@ pod 'SwipeTableView'
  
  
  
-###Mode 2
+### Mode 2
 
 ![Mode 2](https://github.com/Roylee-ML/SwipeTableView/blob/master/ScreenShots/SwipeTableViewStruct2.png)
 
@@ -67,9 +67,9 @@ pod 'SwipeTableView'
 >Under normal conditions, it is `Mode 1`; For `Mode 2`, set the macro `#define ST_PULLTOREFRESH_HEADER_HEIGHT xx` in the `SwipeTableView.h` or the PCH file.
 
 <br>
-#Basic Usage
+# Basic Usage
 
-##How to use it? Just like UITableView
+## How to use it? Just like UITableView
 
 **Conform protocol `SwipeTableViewDataSource` and implement the two methods below：**
 
@@ -89,9 +89,9 @@ pod 'SwipeTableView'
 **The `swipeHeaderView` must be `STHeaderView` or subclass of `STHeaderView`**
  
 <br>
-##How to support pull to refersh?
+## How to support pull to refersh?
 
-###There is two ways to support pull to refresh, one is custom pull to refresh by yourself(just custom part), another is set a macro simply and crudely
+### There is two ways to support pull to refresh, one is custom pull to refresh by yourself(just custom part), another is set a macro simply and crudely
 
 <br>
 
@@ -171,7 +171,7 @@ How to judge the frame of the RefreshHeader of refresh control is constant?
 
  
 <br>
-##Hybrid (UItableView & UICollectionView & UIScrollView)
+## Hybrid (UItableView & UICollectionView & UIScrollView)
 
 1. In basic mode `Model 1`, has the best extensibility, it supports `UITableView`、`UICollectionView`、`UIScrollView`.**If you set the property `shouldAdjustContentSize` YES to adjust the contentSize of itemView, you shuld only use `STCollectionView` its subcalss when your itemView is `UICollectionView` and its contentinfo is less**
 
@@ -180,8 +180,8 @@ How to judge the frame of the RefreshHeader of refresh control is constant?
 2. In `Model 2`, **collectionView you used must be kind of `SwipeTableView`**, now, not support `UIScrollView`.
 
 <br>
-##**Example Code**：
-###Init, set header and bar
+## **Example Code**：
+### Init, set header and bar
 
 ```objc
 self.swipeTableView = [[SwipeTableView alloc]initWithFrame:[UIScreen mainScreen].bounds];
@@ -193,7 +193,7 @@ _swipeTableView.swipeHeaderBar = self.segmentBar;
 
 ```
    
-###Conform the protocol：
+### Conform the protocol：
 
 ```objc
 - (NSInteger)numberOfItemsInSwipeTableView:(SwipeTableView *)swipeView {
@@ -214,7 +214,7 @@ _swipeTableView.swipeHeaderBar = self.segmentBar;
 }
 ```
    
-###How to use `STCollectionView`:
+### How to use `STCollectionView`:
 
 ```objc
 MyCollectionView.h
@@ -331,7 +331,7 @@ MyCollectionView.m
 <br>
 # Demo Info
 
-###Detailed usages are in the SwipeTableViewDemo folder, provide five examples:
+### Detailed usages are in the SwipeTableViewDemo folder, provide five examples:
 
   - `SingleOneKindView`   
      The itemView is just one kind, it is `CustomTableView` (subclass of `UITableView`) in the demo


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
